### PR TITLE
Separate ENTRYPOINT and CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,5 @@ COPY --from=builder /deps/lib64/*.so.* /lib64/
 
 EXPOSE 5065 5064
 
-ENTRYPOINT ["softIoc", "-d", "/db/softioc.db"]
+ENTRYPOINT ["softIoc"]
+CMD ["-d", "/db/softioc.db"]


### PR DESCRIPTION
Nice softIoc Docker image! 👍

This change makes it more transparent: what's the executable and what are default arguments.
This way it's easy to override the default arguments `-d /db/softioc.db` when running the container:

    docker run --rm -it -v $(pwd):/db slominskir/softioc -m user=pklaus -d /db/my.db